### PR TITLE
Add peach-probe to list of services and refactor constants to constants.py

### DIFF
--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -1,35 +1,9 @@
 #!/usr/bin/env python3
+from constants import *
 
 import subprocess
 import os
 
-
-GPG_KEY_EMAIL = "andrew@mycelial.technology"
-# save the key passphrase to file and assign the path here:
-# (ensure the file is only readable by the user running freight)
-GPG_KEY_PASS_FILE = "/home/rust/passphrase.txt"
-
-
-FREIGHT_CONF = "/etc/freight.conf"
-MICROSERVICES_SRC_DIR = "/srv/peachcloud/automation/microservices"
-MICROSERVICES_DEB_DIR = "/srv/peachcloud/debs"
-USER_PATH = "/home/rust"
-
-
-SERVICES = [
-    {"name": "peach-buttons",
-     "repo_url": "https://github.com/peachcloud/peach-buttons.git"},
-    {"name": "peach-menu", "repo_url": "https://github.com/peachcloud/peach-menu.git"},
-    {"name": "peach-monitor",
-     "repo_url": "https://github.com/peachcloud/peach-monitor.git"},
-    {"name": "peach-network",
-     "repo_url": "https://github.com/peachcloud/peach-network.git"},
-    {"name": "peach-oled", "repo_url": "https://github.com/peachcloud/peach-oled.git"},
-    {"name": "peach-stats", "repo_url": "https://github.com/peachcloud/peach-stats.git"},
-    # {"name": "peach-web", "repo_url": "https://github.com/peachcloud/peach-web.git"}, # currently build fails because it needs rust nightly for pear
-]
-
-cargo_path = os.path.join(USER_PATH, ".cargo/bin/cargo")
 
 print("[ BUILDING AND UPDATING MICROSERVICE PACKAGES ]")
 for service in SERVICES:
@@ -39,7 +13,7 @@ for service in SERVICES:
     subprocess.call(["git", "pull"], cwd=service_path)
     debian_package_path = subprocess.run(
         [
-            cargo_path,
+            CARGO_PATH,
             "deb",
             "--target",
             "aarch64-unknown-linux-gnu"],

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,30 @@
+# constants used by build and setup scripts
+import os
+
+# before running this script run `gpg --gen-key` on the server
+# assign the email address of the key id here:
+GPG_KEY_EMAIL = "andrew@mycelial.technology"
+GPG_KEY_PASS_FILE = "/home/rust/passphrase.txt"
+
+AUTOMATION_DIR = "/srv/peachcloud/automation"
+FREIGHT_CONF = "/etc/freight.conf"
+FREIGHT_LIB = "/var/lib/freight"
+FREIGHT_CACHE = "/var/www/apt.peachcloud.org"
+MICROSERVICES_SRC_DIR = "/srv/peachcloud/automation/microservices"
+MICROSERVICES_DEB_DIR = "/srv/peachcloud/debs"
+USER_PATH = "/home/rust"
+CARGO_PATH = os.path.join(USER_PATH, ".cargo/bin/cargo")
+
+SERVICES = [
+    {"name": "peach-buttons",
+     "repo_url": "https://github.com/peachcloud/peach-buttons.git"},
+    {"name": "peach-menu", "repo_url": "https://github.com/peachcloud/peach-menu.git"},
+    {"name": "peach-monitor",
+     "repo_url": "https://github.com/peachcloud/peach-monitor.git"},
+    {"name": "peach-network",
+     "repo_url": "https://github.com/peachcloud/peach-network.git"},
+    {"name": "peach-oled", "repo_url": "https://github.com/peachcloud/peach-oled.git"},
+    {"name": "peach-stats", "repo_url": "https://github.com/peachcloud/peach-stats.git"},
+    {"name": "peach-probe", "repo_url": "https://github.com/peachcloud/peach-probe.git"},
+    # {"name": "peach-web", "repo_url": "https://github.com/peachcloud/peach-web.git"}, # currently build fails because it needs rust nightly for pear
+]

--- a/scripts/setup_build_env.py
+++ b/scripts/setup_build_env.py
@@ -1,39 +1,12 @@
 #!/usr/bin/env python3
 
 from utils import render_template
+from constants import *
 
 import subprocess
-import os
 import argparse
+import os
 
-# before running this script run `gpg --gen-key` on the server
-# assign the email address of the key id here:
-GPG_KEY_EMAIL = "andrew@mycelial.technology"
-
-
-# constants
-AUTOMATION_DIR = "/srv/peachcloud/automation"
-FREIGHT_CONF = "/etc/freight.conf"
-FREIGHT_LIB = "/var/lib/freight"
-FREIGHT_CACHE = "/var/www/apt.peachcloud.org"
-MICROSERVICES_SRC_DIR = "/srv/peachcloud/automation/microservices"
-USER_PATH = "/home/rust"
-
-
-SERVICES = [
-    {"name": "peach-buttons",
-     "repo_url": "https://github.com/peachcloud/peach-buttons.git"},
-    {"name": "peach-menu", "repo_url": "https://github.com/peachcloud/peach-menu.git"},
-    {"name": "peach-monitor",
-     "repo_url": "https://github.com/peachcloud/peach-monitor.git"},
-    {"name": "peach-network",
-     "repo_url": "https://github.com/peachcloud/peach-network.git"},
-    {"name": "peach-oled", "repo_url": "https://github.com/peachcloud/peach-oled.git"},
-    {"name": "peach-stats", "repo_url": "https://github.com/peachcloud/peach-stats.git"},
-    # {"name": "peach-web", "repo_url": "https://github.com/peachcloud/peach-web.git"}, # currently build fails because it needs rust nightly for pear
-]
-
-cargo_path = os.path.join(USER_PATH, ".cargo/bin/cargo")
 
 # parse CLI args
 parser = argparse.ArgumentParser()
@@ -87,7 +60,7 @@ else:
     print("[ INSTALLING CARGO-DEB ]")
     cargo_deb_path = os.path.join(USER_PATH, ".cargo/bin/cargo-deb")
     if not os.path.exists(cargo_deb_path):
-        subprocess.call([cargo_path, "install", "cargo-deb"])
+        subprocess.call([CARGO_PATH, "install", "cargo-deb"])
 
     print("[ INSTALL TOOLCHAIN FOR CROSS-COMPILATION ]")
     rustup_path = os.path.join(USER_PATH, ".cargo/bin/rustup")


### PR DESCRIPTION
- refactors constants into constants.py so that they can be shared by build_packages.py and setup_build_env.py 
- adds peach-probe to list of packages to build 

build_packages.py and setup_build_env.py were tested and working on the vps 