### PR TITLE
Add -d option for build_packages to ensure default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-vps
 
-![Generic badge](https://img.shields.io/badge/version-0.3.0-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-0.3.1-<COLOR>.svg)
 
 Scripts for configuring the PeachCloud VPS for various hosting and automation functions.
 

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -3,6 +3,7 @@ from constants import *
 
 import subprocess
 import argparse
+import sys
 import os
 
 

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -3,7 +3,6 @@ from constants import *
 
 import subprocess
 import argparse
-import sys
 import os
 
 
@@ -27,9 +26,7 @@ for service in SERVICES:
         # because some repo have main as default and some as master, we get the default
         default_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'origin/HEAD'],
                                                  cwd=service_path).decode(sys.stdout.encoding)
-        print("default: {}".format(default_branch))
         branch = default_branch.replace('origin/', '').strip()
-        print("branch: {}".format(branch))
         subprocess.run(["git", "checkout", branch], cwd=service_path)
         subprocess.run(["git", "reset", "HEAD", "--hard"], cwd=service_path)
         subprocess.run(["git", "pull"], cwd=service_path)


### PR DESCRIPTION
While working on building the peach-image, I took advantage of the fact that on the VPS we can build packages with code that is not from the main/master/default branch (useful for building stuff which is not yet merged). 

However, this leads to repos on the vps potentially being in the wrong branch, and this causing a headache in the future. 

So, here I've added a -d flag to build_packages.py which ensures that all repos are in the correct default branch (main or master) before building the packages