### PR TITLE
Add script to build peach-go-sbot debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ secret*
 secret_files*
 ssh.sh
 notes.txt
+*__pycache__*

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ python3 -u scripts/build_packages.py
 
 Freight supports the ability to have multiple versions of a package in a single Debian package archive. If a particular version of a package already exists in the Freight library, it will not be readded or overwritten.
 
-## Build peach-go-sbot debian package
+## Build peach-go-sbot Debian package
 
 `sudo python3 scripts/build_peach_go_sbot.py -v <version_number>`
 
-This build the peach-go-sbot package using the latest code from go-ssb, along with a systemd unit file,
-and adds the debian package to the freight library.
+This builds the peach-go-sbot package using the latest code from go-ssb, along with a systemd unit file,
+and adds the Debian package to the Freight library.
 
 ## Install Packages from Debian Package Archive
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ python3 -u scripts/build_packages.py
 
 Freight supports the ability to have multiple versions of a package in a single Debian package archive. If a particular version of a package already exists in the Freight library, it will not be readded or overwritten.
 
+## Build peach-go-sbot debian package
+
+`sudo python3 scripts/build_peach_go_sbot.py -v <version_number>`
+
+This build the peach-go-sbot package using the latest code from go-ssb, along with a systemd unit file,
+and adds the debian package to the freight library.
+
 ## Install Packages from Debian Package Archive
 
 To add the PeachCloud Debian package archive as an apt source, run the following commands from your Pi:

--- a/conf/templates/peach_go_sbot/DEBIAN/control
+++ b/conf/templates/peach_go_sbot/DEBIAN/control
@@ -1,0 +1,5 @@
+Package: peach-go-sbot
+Version: {{version}}
+Architecture: all
+Maintainer: Andrew Reid <gnomad@cryptolab.net>
+Description: debian package for go-ssb-server on arm64

--- a/conf/templates/peach_go_sbot/DEBIAN/postinst
+++ b/conf/templates/peach_go_sbot/DEBIAN/postinst
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+# create user which go-sbot runs as
+adduser --quiet --system peach-go-sbot
+
+# set permissions
+chown peach-go-sbot /usr/bin/go-sbot
+
+# Automatically added by cargo-deb
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# This will only remove masks created by d-s-h on package removal.
+	deb-systemd-helper unmask peach-go-sbot.service >/dev/null || true
+
+	# was-enabled defaults to true, so new installations run enable.
+	if deb-systemd-helper --quiet was-enabled peach-go-sbot.service; then
+		# Enables the unit on first installation, creates new
+		# symlinks on upgrades if the unit file has changed.
+		deb-systemd-helper enable peach-go-sbot.service >/dev/null || true
+	else
+		# Update the statefile to add new symlinks (if any), which need to be
+		# cleaned up on purge. Also remove old symlinks.
+		deb-systemd-helper update-state peach-go-sbot.service >/dev/null || true
+	fi
+fi
+# End automatically added section
+# Automatically added by cargo-deb
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		if [ -n "$2" ]; then
+			_dh_action=restart
+		else
+			_dh_action=start
+		fi
+		deb-systemd-invoke $_dh_action peach-go-sbot.service >/dev/null || true
+	fi
+fi
+# End automatically added section

--- a/conf/templates/peach_go_sbot/DEBIAN/postinst
+++ b/conf/templates/peach_go_sbot/DEBIAN/postinst
@@ -6,6 +6,7 @@ adduser --quiet --system peach-go-sbot
 
 # set permissions
 chown peach-go-sbot /usr/bin/go-sbot
+chown peach-go-sbot /usr/bin/sbotcli
 
 # Automatically added by cargo-deb
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then

--- a/conf/templates/peach_go_sbot/DEBIAN/postrm
+++ b/conf/templates/peach_go_sbot/DEBIAN/postrm
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+# Automatically added by cargo-deb
+if [ -d /run/systemd/system ]; then
+	systemctl --system daemon-reload >/dev/null || true
+fi
+# End automatically added section
+# Automatically added by cargo-deb
+if [ "$1" = "remove" ]; then
+	if [ -x "/usr/bin/deb-systemd-helper" ]; then
+		deb-systemd-helper mask peach-go-sbot.service >/dev/null || true
+	fi
+fi
+
+if [ "$1" = "purge" ]; then
+	if [ -x "/usr/bin/deb-systemd-helper" ]; then
+		deb-systemd-helper purge peach-go-sbot.service >/dev/null || true
+		deb-systemd-helper unmask peach-go-sbot.service >/dev/null || true
+	fi
+fi
+# End automatically added section

--- a/conf/templates/peach_go_sbot/DEBIAN/prerm
+++ b/conf/templates/peach_go_sbot/DEBIAN/prerm
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+# Automatically added by cargo-deb
+if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+	deb-systemd-invoke stop peach-go-sbot.service >/dev/null || true
+fi
+# End automatically added section

--- a/conf/templates/peach_go_sbot/peach-go-sbot.service
+++ b/conf/templates/peach_go_sbot/peach-go-sbot.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=peachs go-sbot
+
+[Service]
+Type=simple
+User=peach-go-sbot
+ExecStart=/usr/bin/go-sbot
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/build_peach_go_sbot.py
+++ b/scripts/build_peach_go_sbot.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+script to create debian packages for cross-compiled go binaries for go-sbot
+based off of this post
+https://unix.stackexchange.com/questions/627689/how-to-create-a-debian-package-from-a-bash-script-and-a-systemd-service
+"""
+
+
+from constants import *
+from utils import render_template
+
+import subprocess
+import argparse
+import sys
+import os
+import shutil
+
+DEB_CONF_DIR = os.path.join(PROJECT_PATH, 'conf/templates/peach_go_sbot')
+DEB_BUILD_DIR = "/tmp/peach_go_sbot"
+GO_SSB_DIR = "/srv/peachcloud/automation/go-ssb"
+
+
+def crosscompile_peach_go_sbot():
+    subprocess.check_call(["git", "pull"], cwd=GO_SSB_DIR)
+    # TODO: confirm that version number in the repo matches the version number we set for the package we are building
+    print("[CROSS-COMPILING sbotcli]")
+    subprocess.check_call(["env", "GOOS=linux", "GOARCH=arm64", "go", "build", "./cmd/sbotcli"], cwd=GO_SSB_DIR)
+    print("[CROSS-COMPILING go-sbot]")
+    subprocess.check_call(["env", "GOOS=linux", "GOARCH=arm64", "go", "build", "./cmd/go-sbot"], cwd=GO_SSB_DIR)
+
+def package_peach_go_sbot(version):
+
+    print("[ PACKAGING peach-go-sbot ]")
+    # copy debian conf files into correct locations in package build directory
+    DEBIAN_SRC_DIR = os.path.join(DEB_CONF_DIR, 'DEBIAN')
+    DEBIAN_DEST_DIR = os.path.join(DEB_BUILD_DIR, 'DEBIAN')
+    os.makedirs(DEBIAN_DEST_DIR)
+    maintainer_scripts = ['postinst', 'postrm', 'prerm']
+    for script in maintainer_scripts:
+        src = os.path.join(DEBIAN_SRC_DIR, script)
+        dest = os.path.join(DEBIAN_DEST_DIR, script)
+        shutil.copyfile(src, dest)
+        subprocess.check_call(["chmod", "775", dest])
+    # copy control file putting in correct version number
+    src = os.path.join("peach_go_sbot/DEBIAN/control")
+    dest = os.path.join(DEBIAN_DEST_DIR, "control")
+    render_template(src=src, dest=dest, template_vars={"version": version})
+
+    # copy systemd service file
+    SERVICE_DIR = os.path.join(DEB_BUILD_DIR, 'lib/systemd/system')
+    os.makedirs(SERVICE_DIR)
+    shutil.copyfile(
+        os.path.join(DEB_CONF_DIR, 'peach-go-sbot.service'),
+        os.path.join(SERVICE_DIR, 'peach-go-sbot.service')
+    )
+
+    # copy cross-compiled binaries
+    GO_BINARIES = ['go-sbot', 'sbotcli']
+    BIN_DIR = os.path.join(DEB_BUILD_DIR, 'usr/bin')
+    os.makedirs(BIN_DIR)
+    for go_binary in GO_BINARIES:
+        destination = os.path.join(BIN_DIR, go_binary)
+        shutil.copyfile(
+            os.path.join(os.path.join(GO_SSB_DIR), go_binary),
+            destination
+        )
+        subprocess.check_call(["chmod", "770", destination])
+
+    # create deb package
+    deb_file_name = "peach-go-sbot_{}_arm64.deb".format(version)
+    print("[ CREATING {}]".format(deb_file_name))
+    subprocess.check_call(["dpkg-deb", "-b", ".", deb_file_name], cwd=DEB_BUILD_DIR)
+
+    # add deb package to freight
+    print("[ ADDING PACKAGE TO FREIGHT ]")
+    deb_path = os.path.join(DEB_BUILD_DIR, deb_file_name)
+    subprocess.check_call(["freight", "add", "-c", FREIGHT_CONF, deb_path, "apt/buster"])
+    print("[ ADDING PACKAGE TO FREIGHT CACHE ]")
+    subprocess.call(["sudo", "freight", "cache", "-g",
+                     GPG_KEY_EMAIL, "-p", GPG_KEY_PASS_FILE])
+
+
+def build_peach_go_sbot():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="Set version number for go-sbot",
+    )
+    args = parser.parse_args()
+
+    print("[ BUILDING PEACH-GO-SBOT VERSION {}]".format(args.version))
+
+    # delete build directory if it already exists or create it
+    subprocess.check_call(["rm", "-rf", DEB_BUILD_DIR])
+    if not os.path.exists(DEB_BUILD_DIR):
+        os.makedirs(DEB_BUILD_DIR)
+
+    crosscompile_peach_go_sbot()
+    package_peach_go_sbot(version=args.version)
+
+
+
+if __name__ == '__main__':
+    build_peach_go_sbot()
+

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,6 +1,9 @@
 # constants used by build and setup scripts
 import os
 
+# path to project directory
+PROJECT_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
 # before running this script run `gpg --gen-key` on the server
 # assign the email address of the key id here:
 GPG_KEY_EMAIL = "andrew@mycelial.technology"


### PR DESCRIPTION
There are a few ways to build a debian package, from more low-level to more scripted. 

It seems to me the most polished way to build a debian package for a go binary would be to use one of the go-specific tools, as described here https://go-team.pages.debian.net/packaging.html. But it looks to me like this goes into go land a bit. Ways to make a package which include the "source" and the "package". 

What I did here was make a simple version, which is just a debian package for a binary executable. I cross-compile go to create the binary executable separately, and then I create a debian package around the binary executables. 

The script here, 
- cross-compiles the go-binaries for go-sbot and sbotcli for linux-arm64
- creates the debian package for these binaries along with the relevant systemd unit for go-sbot
- adds the debian package to the freight repo

The debian configuration I ended up using was based off of this SO post:
https://unix.stackexchange.com/questions/627689/how-to-create-a-debian-package-from-a-bash-script-and-a-systemd-service

I ended up the using maintainer scripts that were generated by cargo-deb (as for our other services) but then modified for this service. 

More to discuss, but this is tested on the pi and working. 