### PR TITLE
Use more reliable method of getting latest code from origin/main during package building

### DIFF
--- a/peach_package_builder/build_peach_config.py
+++ b/peach_package_builder/build_peach_config.py
@@ -31,8 +31,8 @@ def build_peach_config(default_branch=True):
                                                  cwd=service_path).decode(sys.stdout.encoding)
         branch = default_branch.replace('origin/', '').strip()
         subprocess.check_call(["git", "checkout", branch], cwd=service_path)
-        subprocess.check_call(["git", "reset", "HEAD", "--hard"], cwd=service_path)
-        subprocess.check_call(["git", "pull"], cwd=service_path)
+        subprocess.check_call(["git", "fetch", "--all"], cwd=service_path)
+        subprocess.check_call(["git", "reset", "--hard", default_branch], cwd=service_path)
     # remove old build dir
     subprocess.check_call([
             "rm",

--- a/peach_package_builder/build_rust_packages.py
+++ b/peach_package_builder/build_rust_packages.py
@@ -36,8 +36,8 @@ def build_rust_packages(default_branch=False):
                                                      cwd=service_path).decode(sys.stdout.encoding)
             branch = default_branch.replace('origin/', '').strip()
             subprocess.check_call(["git", "checkout", branch], cwd=service_path)
-            subprocess.check_call(["git", "reset", "HEAD", "--hard"], cwd=service_path)
-            subprocess.check_call(["git", "pull"], cwd=service_path)
+            subprocess.check_call(["git", "fetch", "--all"], cwd=service_path)
+            subprocess.check_call(["git", "reset", "--hard", default_branch], cwd=service_path)
         debian_package_path = subprocess.check_output(
             [
                 CARGO_PATH,


### PR DESCRIPTION
Based on this SO post https://stackoverflow.com/questions/1125968/how-do-i-force-git-pull-to-overwrite-local-files, 
this PR changes to using `git reset --hard` in order to get the latest code from the default branch for packages it is building (when the -d flag is passed). 

This is a more reliable way to make sure you're building exactly the code you see in github. 

Merging this as its a small change. 