### PR TITLE
Fix -d flag by hardcoding default branch to origin/main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-package-builder
 
-![Generic badge](https://img.shields.io/badge/version-0.3.2-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-0.3.3-<COLOR>.svg)
 
 Scripts for building debian packages for PeachCloud microservices.
 

--- a/peach_package_builder/build_peach_config.py
+++ b/peach_package_builder/build_peach_config.py
@@ -28,8 +28,8 @@ def build_peach_config(default_branch=True):
     if default_branch:
         # because some repo have main as default and some as master, we get the default
         default_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'origin/HEAD'],
-                                                 cwd=service_path).decode(sys.stdout.encoding)
-        branch = default_branch.replace('origin/', '').strip()
+                                                 cwd=service_path).decode(sys.stdout.encoding).strip()
+        branch = default_branch.replace('origin/', '')
         subprocess.check_call(["git", "checkout", branch], cwd=service_path)
         subprocess.check_call(["git", "fetch", "--all"], cwd=service_path)
         subprocess.check_call(["git", "reset", "--hard", default_branch], cwd=service_path)

--- a/peach_package_builder/build_rust_packages.py
+++ b/peach_package_builder/build_rust_packages.py
@@ -33,8 +33,8 @@ def build_rust_packages(default_branch=False):
         if default_branch:
             # because some repo have main as default and some as master, we get the default
             default_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'origin/HEAD'],
-                                                     cwd=service_path).decode(sys.stdout.encoding)
-            branch = default_branch.replace('origin/', '').strip()
+                                                     cwd=service_path).decode(sys.stdout.encoding).strip()
+            branch = default_branch.replace('origin/', '')
             subprocess.check_call(["git", "checkout", branch], cwd=service_path)
             subprocess.check_call(["git", "fetch", "--all"], cwd=service_path)
             subprocess.check_call(["git", "reset", "--hard", default_branch], cwd=service_path)

--- a/peach_package_builder/build_rust_packages.py
+++ b/peach_package_builder/build_rust_packages.py
@@ -31,13 +31,12 @@ def build_rust_packages(default_branch=False):
         print("[ BUILIDING SERVICE {} ]".format(service_name))
         # this arg ensures we build the default branch, otherwise we build what ever is found locally
         if default_branch:
-            # because some repo have main as default and some as master, we get the default
-            default_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'origin/HEAD'],
-                                                     cwd=service_path).decode(sys.stdout.encoding).strip()
-            branch = default_branch.replace('origin/', '')
+            remote_branch = 'origin/main'
+            branch = 'main'
+            subprocess.check_call(["git", "reset", "HEAD", "--hard"])
             subprocess.check_call(["git", "checkout", branch], cwd=service_path)
             subprocess.check_call(["git", "fetch", "--all"], cwd=service_path)
-            subprocess.check_call(["git", "reset", "--hard", default_branch], cwd=service_path)
+            subprocess.check_call(["git", "reset", "--hard", remote_branch], cwd=service_path)
         debian_package_path = subprocess.check_output(
             [
                 CARGO_PATH,

--- a/vpsdeploy.sh
+++ b/vpsdeploy.sh
@@ -1,6 +1,0 @@
-#rsync -avzh --delete -e "ssh -i /Users/maxfowler/.ssh/peach_rsa" . notplants@167.99.136.8:/srv/peachcloud/automation/peach-vps
-KEY_FILE=/Users/notplants/.ssh/peach_rsa
-rsync -avzh --exclude target --exclude .idea --exclude .git --delete -e "ssh -i $KEY_FILE" . notplants@167.99.136.83:/srv/peachcloud/automation/peach-package-builder/
-#ssh -i ./secret_files/do_rsa root@159.89.5.141
-#ssh -i /home/notplants/.ssh/peach_rsa rust@167.99.136.83 'cd /srv/peachcloud/automation/peach-vps/; python3 scripts/build_packages.py'
-#echo "cd /srv/src/peach-vps; python3 scripts/setup_vps.py"


### PR DESCRIPTION
For some reason git-rev-parse was not returning the correct default branch for peach-network. Rather than go deeper into git land, I changed peach-package-builder to just assume that origin/main is the default branch, which I believe we are using for all repos. When you pass the -d flag to peach-package-builder, it ensures that the repo is on the default branch before building the package. 